### PR TITLE
Correct compose() signature.

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,5 @@
 interface Compose {
-  (): string | Composable
+  (): string
 }
 
 export interface Composable {


### PR DESCRIPTION
Shouldn't return a Composable object, always returns a string.