### PR TITLE
Add basic list element.

### DIFF
--- a/src/lib.spec.ts
+++ b/src/lib.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha'
 import { expect } from 'chai'
 
-import { container, line, italic, link } from './lib'
+import { container, line, italic, link, list } from './lib'
 
 describe('Container', () => {
   describe('compose()', () => {
@@ -93,6 +93,17 @@ describe('Link', () => {
 
       // use regex to match italic content, but not composition
       expect(someLink.compose()).to.match(/\[.*italic text.*\]\(link\)/)
+    })
+  })
+})
+
+describe('List', () => {
+  describe('compose()', () => {
+    it('Composes a list of multiple Elements', () => {
+      const someElement = link('a link')
+      const someList = list(['a list item', someElement])
+
+      expect(someList.compose()).to.match(/- .*\n- .*\n/)
     })
   })
 })

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -41,9 +41,17 @@ interface Line extends Composable {
   _tag: 'Line'
 }
 
-export const line = (content: Element): Line => ({
+interface LineOptions {
+  prefix?: string
+}
+
+export const line = (content: Element, options?: LineOptions): Line => ({
   _tag: 'Line',
-  compose: () => composeElement(content) + '\n',
+  compose: () => {
+    const prefix = options?.prefix ? options.prefix : ''
+
+    return `${prefix}${composeElement(content)}\n`
+  },
 })
 
 interface Italic extends Composable {
@@ -62,4 +70,10 @@ interface Link extends Composable {
 export const link = (url: string, text?: InlineElement): Link => ({
   _tag: 'Link',
   compose: () => (text ? `[${composeElement(text)}](${url})` : `<${url}>`),
+})
+
+export const list = (items: Element[]) => ({
+  _tag: 'List',
+  compose: () =>
+    composeArray(items.map((item) => line(item, { prefix: '- ' }))),
 })


### PR DESCRIPTION
- Adds options argument to `line` to allow for easy prefixing, uses
prefixing to append list item lines with '- '.